### PR TITLE
Shift defaults

### DIFF
--- a/lib/shift.rb
+++ b/lib/shift.rb
@@ -1,7 +1,9 @@
 class Shift
   
+  KEY_LENGTH = 5
+  
   def initialize(key, date)
-    @key = key
+    @key = get_key(key)
     @date = get_date(date)
   end
   
@@ -10,6 +12,18 @@ class Shift
       date.strftime('%d%m%y')
     else 
       date
+    end
+  end
+  
+  def get_key(key)
+    if key
+      key
+    else
+      key = ''
+      KEY_LENGTH.times do 
+        key += rand(9).to_s
+      end
+      key
     end
   end
   

--- a/lib/shift.rb
+++ b/lib/shift.rb
@@ -2,7 +2,15 @@ class Shift
   
   def initialize(key, date)
     @key = key
-    @date = date
+    @date = get_date(date)
+  end
+  
+  def get_date(date)
+    if date.is_a? Date
+      date.strftime('%d%m%y')
+    else 
+      date
+    end
   end
   
   def key_split

--- a/test/shift_test.rb
+++ b/test/shift_test.rb
@@ -19,14 +19,23 @@ class ShiftTest < Minitest::Test
     assert_equal [9, 7, 9, 6], @shift.create_offsets
   end
   
-  def test_it_can_get_shifts
-    assert_equal [21, 30, 43, 51], @shift.get_shifts
-  end
-  
   def test_it_can_create_offset_from_date_object
     date = Date.parse('3rd Nov 2018')
     shift = Shift.new('12345', date)
     assert_equal [9, 9, 2, 4], shift.create_offsets
+  end
+  
+  def test_it_can_get_shifts
+    assert_equal [21, 30, 43, 51], @shift.get_shifts
+  end
+  
+  def test_it_can_create_date_string_from_date_object
+    date = Date.parse('3rd Nov 2018')
+    shift = Shift.new('12345', date)
+    assert_equal '031118', shift.get_date(date)
+    date_2 = '121212'
+    shift_2 = Shift.new('12345', date_2)
+    assert_equal '121212', shift_2.get_date(date_2)
   end
   
 end

--- a/test/shift_test.rb
+++ b/test/shift_test.rb
@@ -38,4 +38,10 @@ class ShiftTest < Minitest::Test
     assert_equal '121212', shift_2.get_date(date_2)
   end
   
+  def test_it_can_generate_random_key_if_none_given
+    shift = Shift.new(nil, '121212')
+    assert_instance_of String, shift.get_key(nil)
+    assert_equal 5, shift.get_key(nil).length
+    assert_instance_of Integer, shift.get_key(nil).to_i
+  end
 end

--- a/test/shift_test.rb
+++ b/test/shift_test.rb
@@ -27,6 +27,13 @@ class ShiftTest < Minitest::Test
   
   def test_it_can_get_shifts
     assert_equal [21, 30, 43, 51], @shift.get_shifts
+    date = Date.parse('3rd Nov 2018')
+    shift = Shift.new(nil, date)
+    shifts = shift.get_shifts
+    assert_instance_of Array, shifts
+    assert_equal 4, shifts.length
+    assert_instance_of Integer, shifts.first
+    assert_instance_of Integer, shifts.last
   end
   
   def test_it_can_create_date_string_from_date_object
@@ -43,5 +50,8 @@ class ShiftTest < Minitest::Test
     assert_instance_of String, shift.get_key(nil)
     assert_equal 5, shift.get_key(nil).length
     assert_instance_of Integer, shift.get_key(nil).to_i
+    key_1 = shift.get_key(nil)
+    key_2 = shift.get_key(nil)
+    refute key_1 == key_2
   end
 end

--- a/test/shift_test.rb
+++ b/test/shift_test.rb
@@ -23,4 +23,10 @@ class ShiftTest < Minitest::Test
     assert_equal [21, 30, 43, 51], @shift.get_shifts
   end
   
+  def test_it_can_create_offset_from_date_object
+    date = Date.parse('3rd Nov 2018')
+    shift = Shift.new('12345', date)
+    assert_equal [9, 9, 2, 4], shift.create_offsets
+  end
+  
 end


### PR DESCRIPTION
Adds ability to Shift class to receive nil instead of a key string and a Date object instead of a date string. It will generate a random key as needed and convert the Date object to a string as needed. All tests pass. 