### PR TITLE
Shift attr readers

### DIFF
--- a/lib/shift.rb
+++ b/lib/shift.rb
@@ -2,6 +2,9 @@ class Shift
   
   KEY_LENGTH = 5
   
+  attr_reader :key,
+              :date
+  
   def initialize(key, date)
     @key = get_key(key)
     @date = get_date(date)

--- a/test/shift_test.rb
+++ b/test/shift_test.rb
@@ -45,16 +45,22 @@ class ShiftTest < Minitest::Test
     date = Date.parse('3rd Nov 2018')
     shift = Shift.new('12345', date)
     assert_equal '031118', shift.get_date(date)
+    assert_equal '031118', shift.date
+
     date_2 = '121212'
     shift_2 = Shift.new('12345', date_2)
     assert_equal '121212', shift_2.get_date(date_2)
+    assert_equal '121212', shift_2.date
   end
   
   def test_it_can_generate_random_key_if_none_given
     shift = Shift.new(nil, '121212')
     assert_instance_of String, shift.get_key(nil)
+    assert_instance_of String, shift.key
     assert_equal 5, shift.get_key(nil).length
+    assert_equal 5, shift.key.length
     assert_instance_of Integer, shift.get_key(nil).to_i
+    assert_instance_of Integer, shift.key.to_i
     key_1 = shift.get_key(nil)
     key_2 = shift.get_key(nil)
     refute key_1 == key_2

--- a/test/shift_test.rb
+++ b/test/shift_test.rb
@@ -11,6 +11,11 @@ class ShiftTest < Minitest::Test
     assert_instance_of Shift, @shift
   end
   
+  def test_it_has_attributes
+    assert_equal '12345', @shift.key
+    assert_equal '230714', @shift.date
+  end
+  
   def test_it_can_split_up_key
     assert_equal [12, 23, 34, 45], @shift.key_split
   end


### PR DESCRIPTION
Adds attr_readers to Shift class for key and date. Adds and improves tests accordingly. Shift tests passing. 