### PR TITLE
Move negative shifts

### DIFF
--- a/lib/decryptor.rb
+++ b/lib/decryptor.rb
@@ -2,9 +2,9 @@ require './lib/rotator'
 
 class Decryptor
   
-  def initialize(cipher, shifts)
+  def initialize(cipher, shift)
     @cipher = cipher
-    @shifts = get_negative_shifts(shifts)
+    @shifts = shift.backwards_shifts
   end
   
   def decrypt

--- a/lib/decryptor.rb
+++ b/lib/decryptor.rb
@@ -22,12 +22,5 @@ class Decryptor
       split_cipher << cipher_characters.shift(4)
     end
     split_cipher
-  end
-  
-  def get_negative_shifts(shifts)
-    shifts.map do |shift|
-      -shift
-    end
-  end
-  
+  end  
 end

--- a/lib/encryptor.rb
+++ b/lib/encryptor.rb
@@ -2,9 +2,9 @@ require './lib/rotator'
 
 class Encryptor
   
-  def initialize(message, shifts)
+  def initialize(message, shift)
     @message = message
-    @shifts = shifts
+    @shifts = shift.shifts
   end
   
   def encrypt

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -11,15 +11,14 @@ class Enigma
     end
     
     shift = Shift.new(key, date)
-    shifts = shift.shifts
-    encryptor = Encryptor.new(message, shifts)
+    encryptor = Encryptor.new(message, shift)
     cipher = encryptor.encrypt
     {encryption: cipher, key: shift.key, date: shift.date}
   end
   
   def decrypt(cipher, key, date = Date.today)
     shift = Shift.new(key, date)
-    decryptor = Decryptor.new(cipher, shift.shifts)
+    decryptor = Decryptor.new(cipher, shift)
     message = decryptor.decrypt
     {decryption: message, key: key, date: shift.date}
   end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -11,7 +11,7 @@ class Enigma
     end
     
     shift = Shift.new(key, date)
-    shifts = shift.get_shifts
+    shifts = shift.shifts
     encryptor = Encryptor.new(message, shifts)
     cipher = encryptor.encrypt
     {encryption: cipher, key: shift.key, date: shift.date}
@@ -19,7 +19,7 @@ class Enigma
   
   def decrypt(cipher, key, date = Date.today)
     shift = Shift.new(key, date)
-    decryptor = Decryptor.new(cipher, shift.get_shifts)
+    decryptor = Decryptor.new(cipher, shift.shifts)
     message = decryptor.decrypt
     {decryption: message, key: key, date: shift.date}
   end

--- a/lib/shift.rb
+++ b/lib/shift.rb
@@ -58,7 +58,7 @@ class Shift
     end
   end
   
-  def get_negative_shifts
+  def backwards_shifts
     shifts = get_shifts
     shifts.map do |shift|
       -shift

--- a/lib/shift.rb
+++ b/lib/shift.rb
@@ -58,4 +58,10 @@ class Shift
     end
   end
   
+  def get_negative_shifts
+    shifts = get_shifts
+    shifts.map do |shift|
+      -shift
+    end
+  end
 end

--- a/lib/shift.rb
+++ b/lib/shift.rb
@@ -49,7 +49,7 @@ class Shift
     end
   end
   
-  def get_shifts
+  def shifts
     keys = key_split
     offsets = create_offsets
 
@@ -59,7 +59,6 @@ class Shift
   end
   
   def backwards_shifts
-    shifts = get_shifts
     shifts.map do |shift|
       -shift
     end

--- a/test/decryptor_test.rb
+++ b/test/decryptor_test.rb
@@ -26,9 +26,4 @@ class DecryptorTest < Minitest::Test
     assert_equal expected, decryptor.four_split
   end
   
-  def test_it_can_make_shifts_negative
-    shifts = [3, 27, 73, 20]
-    assert_equal [-3, -27, -73, -20], @decryptor.get_negative_shifts(shifts)
-  end
-  
 end

--- a/test/decryptor_test.rb
+++ b/test/decryptor_test.rb
@@ -5,8 +5,9 @@ class DecryptorTest < Minitest::Test
   
   def setup
     cipher = 'keder ohulw'
-    shifts = [3, 27, 73, 20]
-    @decryptor = Decryptor.new(cipher, shifts)
+    shift = mock
+    shift.stubs(:backwards_shifts).returns([-3, -27, -73, -20])
+    @decryptor = Decryptor.new(cipher, shift)
   end
   
   def test_it_exists
@@ -21,7 +22,9 @@ class DecryptorTest < Minitest::Test
     expected = [['k', 'e', 'd', 'e'], ['r', ' ',  'o', 'h'], ['u', 'l', 'w']]
     assert_equal expected, @decryptor.four_split
     
-    decryptor = Decryptor.new('keder ohulw!', [3, 27, 73, 20])
+    shift = mock
+    shift.stubs(:backwards_shifts).returns([-3, -27, -73, -20])
+    decryptor = Decryptor.new('keder ohulw!', shift)
     expected = [['k', 'e', 'd', 'e'], ['r', ' ',  'o', 'h'], ['u', 'l', 'w', '!']]
     assert_equal expected, decryptor.four_split
   end

--- a/test/encryptor_test.rb
+++ b/test/encryptor_test.rb
@@ -1,11 +1,13 @@
 require './test/test_helper'
 require './lib/encryptor'
+require './lib/shift'
 
 class EncryptorTest < Minitest::Test
   
   def setup
     message = 'hello world'
     shifts = [3, 27, 73, 20]
+    mock = 
     @encryptor = Encryptor.new(message, shifts)
   end
   

--- a/test/encryptor_test.rb
+++ b/test/encryptor_test.rb
@@ -1,14 +1,13 @@
 require './test/test_helper'
 require './lib/encryptor'
-require './lib/shift'
 
 class EncryptorTest < Minitest::Test
   
   def setup
     message = 'hello world'
-    shifts = [3, 27, 73, 20]
-    mock = 
-    @encryptor = Encryptor.new(message, shifts)
+    shift = mock
+    shift.stubs(:shifts).returns([3, 27, 73, 20])
+    @encryptor = Encryptor.new(message, shift)
   end
   
   def test_it_exists
@@ -23,7 +22,9 @@ class EncryptorTest < Minitest::Test
     expected = [['h', 'e', 'l', 'l'], ['o', ' ',  'w', 'o'], ['r', 'l', 'd']]
     assert_equal expected, @encryptor.four_split
     message = 'hello world!'
-    encryptor = Encryptor.new(message, [3, 27, 73, 20])
+    shift = mock
+    shift.stubs(:shifts).returns([3, 27, 73, 20])
+    encryptor = Encryptor.new(message, shift)
     expected = [['h', 'e', 'l', 'l'], ['o', ' ',  'w', 'o'], ['r', 'l', 'd', '!']]
     assert_equal expected, encryptor.four_split
   end

--- a/test/shift_test.rb
+++ b/test/shift_test.rb
@@ -31,10 +31,10 @@ class ShiftTest < Minitest::Test
   end
   
   def test_it_can_get_shifts
-    assert_equal [21, 30, 43, 51], @shift.get_shifts
+    assert_equal [21, 30, 43, 51], @shift.shifts
     date = Date.parse('3rd Nov 2018')
     shift = Shift.new(nil, date)
-    shifts = shift.get_shifts
+    shifts = shift.shifts
     assert_instance_of Array, shifts
     assert_equal 4, shifts.length
     assert_instance_of Integer, shifts.first

--- a/test/shift_test.rb
+++ b/test/shift_test.rb
@@ -67,6 +67,6 @@ class ShiftTest < Minitest::Test
   end
   
   def test_it_can_make_shifts_negative
-    assert_equal [-21, -30, -43, -51], @shift.get_negative_shifts
+    assert_equal [-21, -30, -43, -51], @shift.backwards_shifts
   end
 end

--- a/test/shift_test.rb
+++ b/test/shift_test.rb
@@ -65,4 +65,8 @@ class ShiftTest < Minitest::Test
     key_2 = shift.get_key(nil)
     refute key_1 == key_2
   end
+  
+  def test_it_can_make_shifts_negative
+    assert_equal [-21, -30, -43, -51], @shift.get_negative_shifts
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,3 +3,4 @@ SimpleCov.start
 
 require 'minitest/autorun'
 require 'minitest/pride'
+require 'mocha/minitest'


### PR DESCRIPTION
Moves the negative shifts method from the Decryptor class to the Shift class, and has Enigma pass Encryptor/Decryptor Shift objects rather than arrays. Updates tests accordingly. All tests passing. 